### PR TITLE
fix header

### DIFF
--- a/src/sass/components/_header.scss
+++ b/src/sass/components/_header.scss
@@ -69,6 +69,7 @@
         padding: 6px 18px;
         font-size: 13px;
         font-weight: 500;
+        line-height: 1.5;
         background-color: var(--bnt-background-green);
         border-radius: 30px;
 
@@ -111,7 +112,7 @@
 
     &__link {
         font-size: 16px;
-        line-height: 19px;
+        line-height: 1.19;
         color: var(--text-color-menu);
         text-decoration: none;
         cursor: pointer;


### PR DESCRIPTION
1) В моб версии .menulink line-height: 1.19, был указан в px
2) На таблетке .navigation__btn не был указан line-height, по макету он отличается от моб версии, line-height: 1.5;
Добавила эти изменения